### PR TITLE
Display rename

### DIFF
--- a/localCode/messageApi/api.py
+++ b/localCode/messageApi/api.py
@@ -321,6 +321,11 @@ class Message(Received):
         return False
 
     def getText(self) -> str:
+        if self.item_type == 2:
+            handleName = self.handleName if self.handle_id != 0 else "You"
+            newName = self.group_title
+            return '{} named the conversation "{}".'.format(handleName,
+                                                            newName)
         if self._imageCount >= 1:
             return '{} attachments'.format(len(self.messageParts))
         elif self.text != '':

--- a/localCode/messageApi/api.py
+++ b/localCode/messageApi/api.py
@@ -295,6 +295,9 @@ class Message(Received):
         if len(messageParts) == 0:
             self._messageParts.append(TextPart(text=''))
 
+        if self.item_type == 2:
+            self._messageParts = []
+
         if self.text is not None:
             self.text = ''.join([text[t] for t in range(len(text))
                                  if (ord(text[t]) in range(65536)

--- a/localCode/messageApi/sqlcommands.py
+++ b/localCode/messageApi/sqlcommands.py
@@ -34,7 +34,7 @@ FROM message
 
 RECENT_MESSAGE_SQL = """SELECT ROWID, guid, handle_id, text, date, is_from_me,
                         associated_message_guid, associated_message_type,
-                        is_delivered
+                        is_delivered, item_type, group_title
 FROM message
     INNER JOIN chat_message_join AS CMJ
         ON message.ROWID = CMJ.message_id

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -429,8 +429,8 @@ class MessageHeader(tk.Frame):
 
         # Store a pointer to message object, so when this object is updated
         # we can just call self.update()
-        self.label = tk.Message(self, width=parent.winfo_reqwidth(), text=text,
-                                justify=tk.CENTER, font=('Dosis', 8))
+        self.label = tk.Message(self, width=parent.winfo_width(), text=text,
+                                justify=tk.CENTER, font=('helvetica', 8))
 
         self.label.pack(fill=tk.X, expand=tk.TRUE)
 
@@ -450,7 +450,8 @@ class MessageBubble(tk.Frame):
         self.senderLabel = None
         if addLabel is True:
             senderName = chat.getMessages()[messageId].handleName
-            self.senderLabel = tk.Label(self, height=1, text=senderName)
+            self.senderLabel = tk.Label(self, height=1, text=senderName,
+                                        font=('helvetica', 8))
         self.messageInterior = ttk.Frame(self, padding=6)
         self.reactions = {}
         # Store a pointer to message object, so when this object is updated
@@ -605,10 +606,10 @@ class TextMessageBubble(MessageBubble):
         self.messageInterior.configure(style="RoundedFrame")
         if messageId >= 0:
             self.body = tk.Message(self.messageInterior, padx=0, pady=3,
-                                   bg='#01cdfe', width=maxWidth, font="Dosis")
+                                   bg='#01cdfe', width=maxWidth, font="helvetica")
         else:
             self.body = tk.Message(self.messageInterior, padx=0, pady=3,
-                                   bg='#01ffff', width=maxWidth, font="Dosis")
+                                   bg='#01ffff', width=maxWidth, font="helvetica")
         self.initBody()
 
     def resize(self, event):

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -606,10 +606,12 @@ class TextMessageBubble(MessageBubble):
         self.messageInterior.configure(style="RoundedFrame")
         if messageId >= 0:
             self.body = tk.Message(self.messageInterior, padx=0, pady=3,
-                                   bg='#01cdfe', width=maxWidth, font="helvetica")
+                                   bg='#01cdfe', width=maxWidth,
+                                   font="helvetica")
         else:
             self.body = tk.Message(self.messageInterior, padx=0, pady=3,
-                                   bg='#01ffff', width=maxWidth, font="helvetica")
+                                   bg='#01ffff', width=maxWidth,
+                                   font="helvetica")
         self.initBody()
 
     def resize(self, event):

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -157,9 +157,10 @@ class MessageFrame(VerticalScrolledFrame):
         return False
 
     def createTimeLabel(self, messageDate):
-        timeLabel = tk.Label(self.interior,
-                             text=getTimeText(messageDate))
-        timeLabel.pack()
+        timeLabel = MessageHeader(self.interior,
+                                  getTimeText(messageDate))
+        timeLabel.pack(fill=tk.X)
+        return timeLabel
 
     def needReadReceipt(self, chat, message, lastFromMeId):
         """Return whether or not a read receipt needs to be added to the
@@ -204,15 +205,16 @@ class MessageFrame(VerticalScrolledFrame):
 
         addLabel = self.needSenderLabel(chat, message, prevMessage)
 
+        messageParts = []
         if (self.needTimeLabel(message, prevMessage)):
-            self.createTimeLabel(message.date)
+            timeLabel = self.createTimeLabel(message.date)
+            messageParts.append(timeLabel)
 
         addReceipt = self.needReadReceipt(chat, message, lastFromMeId)
         if addReceipt:
             self.removeOldReadReceipt()
             self.readReceiptMessageId = message.rowid
 
-        messageParts = []
         allowedTypes = ['public.jpeg', 'public.png', 'public.gif',
                         'com.compuserve.gif']
         # If the message is for a group rename

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -215,6 +215,12 @@ class MessageFrame(VerticalScrolledFrame):
         messageParts = []
         allowedTypes = ['public.jpeg', 'public.png', 'public.gif',
                         'com.compuserve.gif']
+        # If the message is for a group rename
+        if message.item_type == 2:
+            text = '{} named the conversation "{}".'.format(message.handleName, message.group_title)
+            nameChange = MessageHeader(self.interior, text)
+            nameChange.pack(fill=tk.X)
+
         for i in range(len(message.messageParts)):
             messagePart = message.messageParts[i]
             lastPart = (i == len(message.messageParts) - 1)
@@ -409,6 +415,18 @@ class MessageMenu(tk.Menu):
         respFrame = self.master.master.master.master.master
         respFrame.currentChat.sendReaction(respFrame.mp, messageId,
                                            reactionValue)
+
+
+class MessageHeader(tk.Frame):
+
+    def __init__(self, parent, text, *args, **kw):
+        tk.Frame.__init__(self, parent, *args, **kw)
+
+        # Store a pointer to message object, so when this object is updated
+        # we can just call self.update()
+        self.label = tk.Message(self, width=parent.winfo_reqwidth(), text=text, justify=tk.CENTER, font=('Dosis', 8))
+
+        self.label.pack(fill=tk.X, expand=tk.TRUE)
 
 
 class MessageBubble(tk.Frame):

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -219,9 +219,7 @@ class MessageFrame(VerticalScrolledFrame):
                         'com.compuserve.gif']
         # If the message is for a group rename
         if message.item_type == 2:
-            newName = message.group_title
-            text = '{} named the conversation "{}".'.format(message.handleName,
-                                                            newName)
+            text = message.getText()
             nameChange = MessageHeader(self.interior, text)
             nameChange.pack(fill=tk.X)
             messageParts.append(nameChange)

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -217,7 +217,9 @@ class MessageFrame(VerticalScrolledFrame):
                         'com.compuserve.gif']
         # If the message is for a group rename
         if message.item_type == 2:
-            text = '{} named the conversation "{}".'.format(message.handleName, message.group_title)
+            newName = message.group_title
+            text = '{} named the conversation "{}".'.format(message.handleName,
+                                                            newName)
             nameChange = MessageHeader(self.interior, text)
             nameChange.pack(fill=tk.X)
             messageParts.append(nameChange)
@@ -425,7 +427,8 @@ class MessageHeader(tk.Frame):
 
         # Store a pointer to message object, so when this object is updated
         # we can just call self.update()
-        self.label = tk.Message(self, width=parent.winfo_reqwidth(), text=text, justify=tk.CENTER, font=('Dosis', 8))
+        self.label = tk.Message(self, width=parent.winfo_reqwidth(), text=text,
+                                justify=tk.CENTER, font=('Dosis', 8))
 
         self.label.pack(fill=tk.X, expand=tk.TRUE)
 

--- a/localCode/messageframe.py
+++ b/localCode/messageframe.py
@@ -220,6 +220,7 @@ class MessageFrame(VerticalScrolledFrame):
             text = '{} named the conversation "{}".'.format(message.handleName, message.group_title)
             nameChange = MessageHeader(self.interior, text)
             nameChange.pack(fill=tk.X)
+            messageParts.append(nameChange)
 
         for i in range(len(message.messageParts)):
             messagePart = message.messageParts[i]
@@ -427,6 +428,12 @@ class MessageHeader(tk.Frame):
         self.label = tk.Message(self, width=parent.winfo_reqwidth(), text=text, justify=tk.CENTER, font=('Dosis', 8))
 
         self.label.pack(fill=tk.X, expand=tk.TRUE)
+
+    def update(self):
+        pass
+
+    def resize(self, event):
+        self.label.configure(width=event.width)
 
 
 class MessageBubble(tk.Frame):

--- a/localCode/runtests.sh
+++ b/localCode/runtests.sh
@@ -7,5 +7,5 @@ for filename in ${FILES[@]}; do
 		EXITSTATUS=1
 	fi
 done
-echo "Exiting with status " $EXITSTATUS
+echo "Exiting with status" $EXITSTATUS
 exit $EXITSTATUS

--- a/tests/testMessageframe.py
+++ b/tests/testMessageframe.py
@@ -138,32 +138,32 @@ class TestMessageFrameMethods(unittest.TestCase):
     def test_create_time_label_today(self):
         t = datetime.now() - timedelta(hours=2)
         correctText = mf.getTimeText(t.timestamp())
-        self.messageFrame.createTimeLabel(t.timestamp())
 
+        timeLabel = self.messageFrame.createTimeLabel(t.timestamp())
         children = self.messageFrame.interior.winfo_children()
 
         self.assertEqual(len(children), 1)
-        self.assertEqual(children[0].cget('text'), correctText)
+        self.assertEqual(timeLabel.label.cget('text'), correctText)
 
     def test_create_time_label_yesterday(self):
         t = datetime.now() - timedelta(days=1)
         correctText = mf.getTimeText(t.timestamp())
-        self.messageFrame.createTimeLabel(t.timestamp())
 
+        timeLabel = self.messageFrame.createTimeLabel(t.timestamp())
         children = self.messageFrame.interior.winfo_children()
 
         self.assertEqual(len(children), 1)
-        self.assertEqual(children[0].cget('text'), correctText)
+        self.assertEqual(timeLabel.label.cget('text'), correctText)
 
     def test_create_time_label_multiple_days_back(self):
         t = datetime.now() - timedelta(days=10)
         correctText = mf.getTimeText(t.timestamp())
-        self.messageFrame.createTimeLabel(t.timestamp())
 
+        timeLabel = self.messageFrame.createTimeLabel(t.timestamp())
         children = self.messageFrame.interior.winfo_children()
 
         self.assertEqual(len(children), 1)
-        self.assertEqual(children[0].cget('text'), correctText)
+        self.assertEqual(timeLabel.label.cget('text'), correctText)
 
     def test_need_read_receipt_temporary_from_me(self):
         msg = api.Message(ROWID=-1, is_from_me=1)
@@ -295,7 +295,7 @@ class TestMessageFrameMethods(unittest.TestCase):
         self.messageFrame.addMessage(chat, i, message, prevMessage, lastFromMeId)
 
         self.assertIn(message.rowid, self.messageFrame.messageBubbles)
-        self.assertEqual(len(self.messageFrame.messageBubbles[message.rowid]), 2)
+        self.assertEqual(len(self.messageFrame.messageBubbles[message.rowid]), 3)
         for bubble in self.messageFrame.messageBubbles[message.rowid]:
             self.assertEqual(bubble.pack_info()['anchor'], 'w')
 
@@ -312,7 +312,7 @@ class TestMessageFrameMethods(unittest.TestCase):
         self.messageFrame.addMessage(chat, i, message, prevMessage, lastFromMeId)
 
         self.assertIn(message.rowid, self.messageFrame.messageBubbles)
-        self.assertEqual(len(self.messageFrame.messageBubbles[message.rowid]), 2)
+        self.assertEqual(len(self.messageFrame.messageBubbles[message.rowid]), 3)
         for bubble in self.messageFrame.messageBubbles[message.rowid]:
             self.assertEqual(bubble.pack_info()['anchor'], 'e')
 


### PR DESCRIPTION
- Create MessageHeader class for renamed group chat messages and adapt time labels to use this object instead of a regular tk Label.
- Treat item_type 2 messages (group chat renames) as special messages in the message API
    - Perhaps this should be made a subclass of Received later on